### PR TITLE
fix: explicitly define server ids

### DIFF
--- a/inventory.yml
+++ b/inventory.yml
@@ -9,6 +9,7 @@ all:
       squad_server_user: asgard
       squad_server_group: asgard
       squad_default_settings:
+        server_id: 0 # As a note, server IDs must be started at 1!
         docker:
           name: vanilla-squad
           images:
@@ -350,6 +351,7 @@ all:
 
       squad_servers:
         - name: "[ASG] Asgard Eternal | New Player Friendly"
+          server_id: 1
           docker:
             name: vanilla
             images:
@@ -376,6 +378,7 @@ all:
             - Harju_RAAS_v6
 
         - name: "[ASG] Asgard Eternal | MEE - New Player Friendly"
+          server_id: 2
           docker:
             name: mee-french
             images:

--- a/roles/squad-server/tasks/deploy-configs.yml
+++ b/roles/squad-server/tasks/deploy-configs.yml
@@ -63,7 +63,6 @@
   loop: "{{ squad_servers }}"
   loop_control:
     loop_var: server
-    index_var: server_id
     label: "{{ server.docker.name }}"
 
 - name: Open Squad Server Ports

--- a/roles/squad-server/tasks/nested_servers_loop.yml
+++ b/roles/squad-server/tasks/nested_servers_loop.yml
@@ -8,6 +8,5 @@
     mode: 0644
   loop_control:
     loop_var: server
-    index_var: server_id
     label: "{{ server.name }} -> {{ template_file | basename }}"
   loop: "{{ squad_servers }}"


### PR DESCRIPTION
Prior to this, server ids were set purely based on the position in the inventory. So, if a mistake were made and a server moved up or down in position then the associated ID would be wrong, and the wrong data would be used against it in SquadJS's database. Furthermore, if we were to ever change the format of how servers are in the inventory this would cause a headache as currently server ids are calculated based on position in the inventory. Explicitly defining them while, yes, adding another hard coded value, avoids this headache entirely.